### PR TITLE
add new commands to use standalone script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,17 @@ LinuxToys and it's features' compatibility is only *guaranteed* on the operating
 ## Usage
 - Install the proper package for your operating system from [Releases](https://github.com/psygreg/linuxtoys/releases) and run it from the applications menu or use it directly from source.
 
-### Standalone, directly from source
-`bash <(curl -s https://raw.githubusercontent.com/psygreg/linuxtoys/main/src/linuxtoys.sh)`
+### Standalone
+Paste the command into your terminal to get the script from the source.
+
+### Stable branch
+```bash
+curl -fsSL https://raw.githubusercontent.com/psygreg/linuxtoys/main/src/linuxtoys.sh | bash
+```
+### Dev branch
+```bash
+curl -fsSL https://raw.githubusercontent.com/psygreg/linuxtoys/main/src/linuxtoys.sh | sh
+```
 
 ### Ubuntu (latest and latest LTS releases)
 There's a PPA available for LinuxToys. To use it:


### PR DESCRIPTION
# Description of Changes
Estes novos comandos funcionam melhor para pessoas que usam shells ou terminais menos populares, como o [fish shell](https://fishshell.com/), ao rodar o comando anterior no meu shell nada acontecia, com a minha mudança na sintaxe isso funciona de forma mais simples em qualquer combinação de terminal e shell.

Eu também coloquei um novo comando que permite rodar o script da branch de desenvolvimento (dev), útil para usuários mais "apressados".

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

<!-- - [x] Bug fix -->
<!-- - [x] New feature -->
[x] Documentation
