### PR TITLE
refactor: No need to add a widget to have margin

### DIFF
--- a/p3/app/window.py
+++ b/p3/app/window.py
@@ -249,11 +249,7 @@ class AppWindow(Gtk.ApplicationWindow):
             icon_widget.set_pixel_size(icon_size) ## altura dos icones
         icon_widget.set_halign(Gtk.Align.END)
         icon_widget.set_valign(Gtk.Align.CENTER)
-        box.pack_start(icon_widget, False, False, 0)
-
-        right_pad = Gtk.Label()
-        right_pad.set_size_request(10, 1)
-        box.pack_start(right_pad, False, False, 0)
+        box.pack_start(icon_widget, False, False, 20)
 
         event_box = Gtk.EventBox()
         event_box.add(box)


### PR DESCRIPTION
Simple detail...
- Using label to add margin  (*Original)

![original](https://github.com/user-attachments/assets/e7b2ec08-3bc4-4342-80b7-5b8def0e25d1)

- Now
![after](https://github.com/user-attachments/assets/b1b4adb4-a840-48d4-8250-6acc0db85db5)
