### PR TITLE
refactor: Install for user does not need sudo

### DIFF
--- a/p3/scripts/devs/jetbrains-toolbox.sh
+++ b/p3/scripts/devs/jetbrains-toolbox.sh
@@ -9,14 +9,14 @@ SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$SCRIPT_DIR/../../libs/linuxtoys.lib"
 _lang_
 source "$SCRIPT_DIR/../../libs/lang/${langfile}.lib"
-sudo_rq
 
 PKG_NAM="jetbrains-toolbox"
 PKG_URL="$(curl -fsSL 'https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release' | grep -Pio '"linux":\{"link":"\K[^"]+')"
 
-curl -fsSL "${PKG_URL}" -o- | sudo tar -xzvf - --strip-components=2 --one-top-level="$HOME/.local/${PKG_NAM}" && {
+curl -fsSL "${PKG_URL}" -o- | tar -xzvf - --strip-components=2 --one-top-level="${HOME}/.local/${PKG_NAM}" && {
 	(
-		sudo install -Dm 0644 "$HOME/.local/${PKG_NAM}/${PKG_NAM}.desktop" "/usr/local/share/applications/${PKG_NAM}.desktop";
-		sudo ln -v -s "$HOME/.local/${PKG_NAM}/${PKG_NAM}" "/usr/local/bin/";
+		## .desktop file
+		sed -i "/^Exec=/s|^.*$|Exec=${HOME}/.local/${PKG_NAM}/${PKG_NAM}|" ${HOME}/.local/${PKG_NAM}/${PKG_NAM}.desktop;
+		install -Dvm 0644 ${HOME}/.local/${PKG_NAM}/${PKG_NAM}.desktop ${HOME}/.local/share/applications/${PKG_NAM}.desktop;
 	) && { zeninf "$msg018"; }
 } || { exit 1; }


### PR DESCRIPTION
As it is I had problems with the launcher, so wouldn't it be easier to simply change the executable path to `local` so you don't even need sudo?
