### PR TITLE
fix: Item create local script

### DIFF
--- a/p3/app/parser.py
+++ b/p3/app/parser.py
@@ -174,6 +174,25 @@ def get_scripts_for_category(category_path, translations=None):
     Returns a list of scripts and subcategories for a given category.
     """
     items = []
+
+    # Add "Create New Script" option when viewing local scripts directory
+    if category_path.endswith('.local/linuxtoys/scripts'):
+        create_script_name = translations.get('create_new_script_name', 'Create New Script') if translations else 'Create New Script'
+        create_script_desc = translations.get('create_new_script_desc', 'Create a new local script') if translations else 'Create a new local script'
+
+        create_script_item = {
+            'name': create_script_name,
+            'description': create_script_desc,
+            'icon': 'document-new',
+            'path': category_path,
+            'is_script': False,
+            'is_subcategory': False,
+            'is_create_script': True  # Special flag to identify this option
+        }
+
+        # Insert at the beginning so it appears first
+        items.insert(0, create_script_item)
+
     if not os.path.isdir(category_path):
         return items
 
@@ -241,23 +260,6 @@ def get_scripts_for_category(category_path, translations=None):
             script_info['is_subcategory'] = False
             items.append(script_info)
 
-    # Add "Create New Script" option when viewing local scripts directory
-    if '.local/linuxtoys/scripts' in category_path:
-        create_script_name = translations.get('create_new_script_name', 'Create New Script') if translations else 'Create New Script'
-        create_script_desc = translations.get('create_new_script_desc', 'Create a new local script') if translations else 'Create a new local script'
-        
-        create_script_item = {
-            'name': create_script_name,
-            'description': create_script_desc,
-            'icon': 'document-new',
-            'path': category_path,
-            'is_script': False,
-            'is_subcategory': False,
-            'is_create_script': True  # Special flag to identify this option
-        }
-        
-        # Insert at the beginning so it appears first
-        items.insert(0, create_script_item)
 
     return sorted(items, key=lambda s: (not s.get('is_create_script', False), not s.get('is_subcategory', False), s['name']))
 


### PR DESCRIPTION
Category item to create local scripts does not appear if there is no `~/.local/linuxtoys/scripts` directory, this solution avoids creating it if the user just clicks on the `Local Script` category and does not want to create a script, so it is only created by `handle`... Of course there are others but this is a small contribution...

---

I noticed you removed the option to create from the drop-down menu, but I still think there should be an option to create local scripts there, because if the user just wants to create them, they'll always have to go into the subcategories...

As well as the option to export all, because exporting them one by one is exhausting...