### PR TITLE
fix: sudo request via interface

### DIFF
--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -1,5 +1,8 @@
 ## linuxtoys function library
 source /etc/os-release
+shopt -s expand_aliases
+export SUDO_ASKPASS="${SCRIPT_DIR}/libs/zpass.sh"
+alias sudo="sudo -A "
 
 # sudo request
 sudo_rq () { 

--- a/p3/libs/zpass.sh
+++ b/p3/libs/zpass.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+zenity --password --title="Autenthication is needed"


### PR DESCRIPTION
I noticed you're having a lot of issues with this...

To maintain compatibility, a small contribution...

closes #217 #216

---

But that doesn't solve the problem when arch/based need to run `makepkg`, because you need to indicate which authenticator as I already explained, two alternatives, without having to change much...



1. Specify the authenticator for makepkg.
```
cat /etc/makepkg.conf <(echo "PACMAN_AUTH=(sudo -A)") > /tmp/.mk.conf
makepkg -di --config /tmp/.mk.conf --noconfirm
``` 

2. Or, don't ask makepkg to install it and leave it to pacman.
```
makepkg -d
sudo pacman --noconfirm -U package-name-*.tar.zst
```
