### PR TITLE
fix: pacman install with wildcard

### DIFF
--- a/p3/scripts/drivers/rtl8821ce-arch.sh
+++ b/p3/scripts/drivers/rtl8821ce-arch.sh
@@ -21,7 +21,7 @@ _packages=(linux-headers dkms bc base-devel)
 _install_
 cd rtl8821ce-dkms-git
 makepkg -d
-sudo pacman --noconfirm -U rtl8821ce-dkms-git.tar.zst
+sudo pacman --noconfirm -U rtl8821ce-dkms-git-*.tar.zst
 # blacklist rtw88_8821ce, which is borked
 if [ -f /etc/modprobe.d/blacklist.conf ]; then
     if grep -q "blacklist rtw88_8821ce" /etc/modprobe.d/blacklist.conf; then

--- a/p3/scripts/extra/lsw.sh
+++ b/p3/scripts/extra/lsw.sh
@@ -110,7 +110,7 @@ get_winboat () { # gets latest release
         git clone https://aur.archlinux.org/winboat-bin.git
         cd winboat-bin || exit 1
         makepkg -d
-        sudo pacman --noconfirm -U winboat-bin.tar.zst
+        sudo pacman --noconfirm -U winboat-bin-*.tar.zst
     fi
 }
 # runtime


### PR DESCRIPTION
Using wildcard because otherwise it won't find the packages, the way it is...

In the case of `lsw`, is there any need to install FreeRDP via `flatpak` in arch? And `docker` and `docker-compose`, manually, isn't it easier to let `pacman` itself when installing `winboat` resolve its dependencies?
