### PR TITLE
fix: Unnecessary install outside

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -178,12 +178,9 @@ case "${ID:-}" in
             echo "Failed to download: $arch_url_post"
             exit 4
         fi
-        if [ "$ID" = "cachyos" ]; then # install missing dependency (no Arch/Extra repo)
-            wget https://raw.githubusercontent.com/psygreg/linuxtoys/refs/heads/master/resources/cachyos/x11-ssh-askpass-1.2.4.1-8-x86_64.pkg.tar.zst
-            sudo pacman -U --noconfirm x11-ssh-askpass-*.pkg.tar.zst
-            rm x11-ssh-askpass-*.pkg.tar.zst
-        fi
-        makepkg -i || {
+        makepkg -d && {
+            sudo pacman -U --noconfirm linuxtoys-*.pkg.tar.zst;
+        } || {
             echo "Installation failed (pacman)."
             rm -f "$arch_pkg"
             rm -f "$arch_post_inst"


### PR DESCRIPTION
Testing on cachyos and is worked well...

---

Furthermore, I don't see why askpass shouldn't do as I showed you in a previous PR...

After all, you don't have to keep resolving dependencies, which only hinders portability, which is different for each distro. Furthermore, it eliminates design consistency.

- With x11-ssh-askpass
<img width="878" height="688" alt="with-x11-askpass" src="https://github.com/user-attachments/assets/b997ab01-e48a-403d-a610-4b597e3548af" />

- With zpass
<img width="868" height="694" alt="with-zpass" src="https://github.com/user-attachments/assets/42e5c95f-fe04-412e-a7b2-931f942e4722" />

---

But not only the design but if the user accidentally presses to cancel the `x11-ssh-askpass` prompt it will ask for the password in the terminal which does not happen using the `alias` in addition if the user is in an environment without `xwayland` the `x11-ssh-askpass` fails and enters lock condition...

