### PR TITLE
fix: Default for unset GPU header

### DIFF
--- a/p3/app/compat.py
+++ b/p3/app/compat.py
@@ -434,7 +434,7 @@ def script_is_compatible(script_path, compat_keys):
         pass
     
     os_compatible = True
-    gpu_compatible = 'gpu' in compat_keys  # Default for unset GPU header
+    gpu_compatible = True  # Default for unset GPU header
     desktop_compatible = True  # Default for unset desktop header
     
     try:


### PR DESCRIPTION
No script is shown if `gpu` compatibility is not defined in its header, or if the `lspci` utility is not found, which is also part of a collection of other scripts but does not show it as a dependency...