### PR TITLE
fix: sudo request when sudo-rs

### DIFF
--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -7,7 +7,12 @@ sudo_rq () {
     if [ -f /tmp/linuxtoys_sudo_validated ]; then
         return 0
     fi
-    sudo -Av
+    if command -v sudo-rs >&-;then
+        _pass=$(zenity --password --title="LinuxToys")
+	echo "${_pass}" | sudo-rs -Sv
+    else
+        sudo -Av
+    fi
     if [ "$(sudo whoami)" = "root" ]; then
     # Validate password with sudo
         if [ -n "$LINUXTOYS_CHECKLIST" ]; then


### PR DESCRIPTION
This PR applies a temporary mitigation for the close #267, until the [Add support for -A (askpass) commandline switch](https://github.com/trifectatechfoundation/sudo-rs/issues/1249) is resolved in the main-stream.

But testing with the pull-request #270, sudo is requested via the embed emulator.
