### PR TITLE
feat: Revealer footer

### DIFF
--- a/p3/app/icons/credits.svg
+++ b/p3/app/icons/credits.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#808080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-at-sign"><circle cx="12" cy="12" r="4"></circle><path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.92 7.94"></path></svg>

--- a/p3/app/icons/report.svg
+++ b/p3/app/icons/report.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#808080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-flag"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"></path><line x1="4" y1="22" x2="4" y2="15"></line></svg>

--- a/p3/app/icons/sponsor.svg
+++ b/p3/app/icons/sponsor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#808080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-heart"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>

--- a/p3/app/icons/wiki.svg
+++ b/p3/app/icons/wiki.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#808080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-book-open"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg>

--- a/p3/app/revealer.py
+++ b/p3/app/revealer.py
@@ -1,0 +1,74 @@
+from .gtk_common import Gtk
+from . import get_icon_path
+
+
+class SupportFooter(Gtk.Box):
+    def __init__(self, translations):
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=20)
+        self.set_margin_top(10)
+        self.translations = translations or {}
+        self.set_margin_bottom(10)
+        self.set_halign(Gtk.Align.CENTER)
+
+        self.urls_labels = [
+            ("https://linux.toys/knowledgebase.html", "Wiki", "wiki.svg"),
+            ("https://github.com/psygreg/linuxtoys/issues/new?template=bug_report.md", self.translations.get('report_label', 'Report Bug'), "report.svg"),
+            ("https://linux.toys/credits.html", self.translations.get('credits_label', 'Credits'), "credits.svg"),
+            ("https://ko-fi.com/psygreg", self.translations.get('support_footer', 'Support this project'), "sponsor.svg")
+        ]
+
+        for i, (url, label, icon) in enumerate(self.urls_labels):
+            link_button = Gtk.LinkButton(uri=url, label=label)
+            if icon_path := get_icon_path(icon):
+                icon_img = Gtk.Image.new_from_file(icon_path)
+                link_button.set_image(icon_img)
+            self.pack_start(link_button, False, False, 0)
+
+            if i < len(self.urls_labels) - 1:
+                separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+                self.pack_start(separator, False, False, 0)
+
+
+class RevealerFooter(Gtk.Revealer):
+    def __init__(self, parent):
+        super().__init__()
+
+        self.parent = parent
+        self.set_transition_type(Gtk.RevealerTransitionType.SLIDE_UP)
+        self.set_transition_duration(300)
+
+        container = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        self.button_box = Gtk.ButtonBox(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        self.button_box.set_layout(Gtk.ButtonBoxStyle.CENTER)
+        self.button_box.set_margin_top(5)
+        self.button_box.set_margin_bottom(5)
+
+        self.button_next = Gtk.Button(label=self.parent.translations.get("next", "Next"))
+        self.button_next.set_image(Gtk.Image.new_from_icon_name("go-next", Gtk.IconSize.BUTTON))
+        self.button_next.set_always_show_image(True)
+        self.button_next.set_tooltip_text(self.parent.translations.get("next", "Next"))
+        self.button_next.set_size_request(125, 35)
+        self.button_next.connect("clicked", self._on_next_clicked)
+
+        self.button_cancel = Gtk.Button(label=self.parent.translations.get("cancel", "Cancel"))
+        self.button_cancel.set_image(Gtk.Image.new_from_icon_name("window-close", Gtk.IconSize.BUTTON))
+        self.button_cancel.set_always_show_image(True)
+        self.button_cancel.set_tooltip_text(self.parent.translations.get("cancel", "Cancel"))
+        self.button_cancel.set_size_request(125, 35)
+        self.button_cancel.connect("clicked", self._on_cancel_clicked)
+
+        self.button_box.add(self.button_cancel)
+        self.button_box.add(self.button_next)
+
+        self.support = SupportFooter(self.parent.translations)
+
+        container.pack_start(self.support, False, False, 0)
+        container.pack_start(self.button_box, False, False, 0)
+        self.add(container)
+
+    def _on_next_clicked(self, button):
+        self.parent.on_install_checklist(button)
+
+    def _on_cancel_clicked(self, button):
+        self.parent.on_cancel_checklist(button)

--- a/p3/app/style.css
+++ b/p3/app/style.css
@@ -1,9 +1,10 @@
-/* Defines the style for each item in our grid (FlowBox) */
+* {
+    outline: none;
+}
 .script-item {
     background-color: rgba(0,0,0,0.1);
-    border: 1px solid rgba(255, 255, 255, 0.3); /* borda branca semi-transparente */
+    border: 1px solid rgba(255, 255, 255, 0.3);
     border-radius: 16px;
-    /* Let GTK use system theme colors automatically */
 }
 .script-item-hover {
     background-color: rgba(255, 255, 255, 0.05);
@@ -21,7 +22,4 @@
 }
 flowboxchild:selected {
     border-radius: 16px;
-}
-flowboxchild {
-    outline: none;
 }


### PR DESCRIPTION
Adding a revealer to the footer...

Now the "Install" button in the checklist is only displayed when more than one option is selected, since if you want just one, just click on it. Plus, you don't have to constantly recreate these buttons.

In addition to other styling features like icons in the footer...