### PR TITLE
fix: Helpers lib not found

### DIFF
--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -1,6 +1,6 @@
 ## linuxtoys function library
 source /etc/os-release
-source helpers.lib
+source "$SCRIPT_DIR/libs/helpers.lib"
 export SUDO_ASKPASS="$SCRIPT_DIR/libs/zpass.sh"
 
 # sudo request


### PR DESCRIPTION
I don't see the real need to include the helpers in `linuxtoys.lib` since it is already included in the scripts that need it, but even so I wasn't finding it because the relative path is not informed correctly, unless you want it to not need to be explicitly included in the future...