### PR TITLE
fix: Avoid back when the script is running

### DIFF
--- a/p3/app/term_view.py
+++ b/p3/app/term_view.py
@@ -135,10 +135,11 @@ class TermRunScripts(Gtk.Box):
 			self.vbox_main.button_run.set_image(Gtk.Image.new_from_icon_name("emblem-ok-symbolic", Gtk.IconSize.BUTTON))
 			self.vbox_main.progress_bar.set_text(done_text)
 			self.vbox_main.button_run.connect("clicked", self.on_done_clicked)
-
+			self.parent._script_running = False
 			self.vbox_main.button_run.set_sensitive(True)
 			return
 
+		self.parent._script_running = True
 		current_script = self.script_queue.pop(0)
 		self.vbox_main._update_header_labels(current_script)
 

--- a/p3/app/window.py
+++ b/p3/app/window.py
@@ -130,6 +130,8 @@ class AppWindow(Gtk.ApplicationWindow):
         # Initialize drag-and-drop but don't enable it by default
         self._setup_drag_and_drop()
 
+        self._script_running = False
+
         GLib.idle_add(self._check_updates)
 
     def _check_updates(self):
@@ -1550,7 +1552,7 @@ source "$SCRIPT_DIR/libs/lang/${{langfile}}.lib"
             return
 
         # Check if a script is currently running
-        if self.main_stack.get_visible_child_name() == "running_scripts":
+        if self._script_running:
             # Show warning dialog before cancelling the running script
             if not self._show_cancel_script_warning_dialog():
                 return  # User cancelled the operation


### PR DESCRIPTION
Avoid returning when the script is actually running, and not just if it is in `VTE` tab...

