### PR TITLE
feat: Add needed metadata

### DIFF
--- a/p3/app/cli_helper.py
+++ b/p3/app/cli_helper.py
@@ -43,6 +43,7 @@ import os
 import sys
 import subprocess
 import shutil
+import asyncio
 from .parser import get_categories, get_all_scripts_recursive
 from .compat import get_system_compat_keys, script_is_compatible, is_containerized, script_is_container_compatible
 from .reboot_helper import check_ostree_pending_deployments
@@ -238,6 +239,11 @@ def find_script_by_name(script_name, translations=None):
                     return script
 
     return None
+
+
+async def find_script_by_name_async(script_name, translations=None):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, find_script_by_name, script_name, translations)
 
 
 def load_manifest(manifest_path='manifest.txt'):

--- a/p3/app/head_menu.py
+++ b/p3/app/head_menu.py
@@ -4,7 +4,7 @@ from . import language_selector
 from . import about_helper
 from . import get_icon_path
 from .lang_utils import create_translator
-import threading
+import threading, asyncio
 import os
 
 
@@ -251,7 +251,8 @@ class MenuButton(Gtk.MenuButton):
 				os.remove(self._temp_sh)
 
 		if self.results:
-			self.parent_window.open_term_view(self.results)
+			deps = asyncio.run(self.parent_window._process_needed_scripts(self.results))
+			self.parent_window.open_term_view(deps)
 
 	def __temp_script(self, packages, flatpaks):
 		lib_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'libs', 'linuxtoys.lib')

--- a/p3/app/parser.py
+++ b/p3/app/parser.py
@@ -113,6 +113,9 @@ def _parse_metadata_file(file_path, default_values, translations=None):
                         # Always capture 'negates' header even if not in defaults
                         elif key == 'negates':
                             metadata['negates'] = value
+                        elif key == 'needed':
+                            metadata['needed'] =  value.split() or None
+
     except Exception as e:
         print(f"Error reading metadata from {file_path}: {e}")
 


### PR DESCRIPTION
Add needed metadata for scripts that may depend on a tool already defined in LinuxToys... such as `portainer` which needs `docker`, to do this, just add...

```
...
# needed: docker
...
```

Furthermore, it can be used, for example, for categories defined as `psy's` collections e.g `psypicks`

