### PR TITLE
fix(libs): Install packages on CachyOS

### DIFF
--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -107,7 +107,7 @@ _install_() {
                 dpkg -s "$pak" &>/dev/null || sudo apt install -y "$pak"
             done
             ;;
-        *arch*|*archlinux*)
+        *arch*|*archlinux*|*cachyos*)
             for pak in "${_packages[@]}"; do
                 pacman -Qi "$pak" &>/dev/null && continue
                 


### PR DESCRIPTION
# Description of Changes

Minor fix where scripts fail when run on CachyOS.

> [!Warning]
> This is probably happening with other base distributions as well, since apparently the new changes haven't been properly checked.

## Type of Change

- [x] Bug fix 