### PR TITLE
refactor(libs): Avoid requesting SUDO in the flatpak lib

### DIFF
--- a/p3/libs/helpers.lib
+++ b/p3/libs/helpers.lib
@@ -23,17 +23,13 @@ flatpak_in_lib() {
     fi
 
     # Add Flathub remote if not exists
-    flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo --user &>/dev/null || \
-        _msg warning "Failed to add Flathub remote for user"
+    if ! flatpak remotes --user | grep -q "flathub" && ! flatpak remotes --system | grep -q "flathub"; then
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo --user &>/dev/null || \
+            _msg warning "Failed to add Flathub remote for user"; return 1;
 
-    sudo_rq
-    sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo --system &>/dev/null|| \
-        _msg warning "Failed to add Flathub remote on system"
-
-    # Verify
-    if ! flatpak remotes --user | grep -q "flathub" && ! flatpak remotes --system | grep -q "flathub" 2>/dev/null; then
-        _msg error "Failed to add Flathub remote"
-        return 1
+        sudo_rq
+        sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo --system &>/dev/null|| \
+            _msg warning "Failed to add Flathub remote on system"; return 1;
     fi
 
     [ -n "$LINUXTOYS_CHECKLIST" ] && touch /tmp/linuxtoys_flatpak_done


### PR DESCRIPTION
# Description of Changes

Now, before adding the Flathub repository, the code checks if it is already present at both the user and system levels, avoiding the need to request the SUDO password with each installation call to `flatpak_in_lib`, which most of these scripts are user-scoped... without requiring unnecessary superuser access...

---

I'd like to ask if it's really necessary to add this to the entire system, since only 7 scripts use it, completely unnecessarily, as adding it to the system scope doesn't grant any special access. Therefore, I'm asking if I can change these scripts to the user scope (--user)? The following [docs](https://docs.flathub.org/docs/for-users/user-vs-system-install) explains why it's not necessary to add it to the system scope (--system)...

## Type of Change

- [x] Refactor
