### PR TITLE
Corrige instalação Flatpak quando o Flathub está somente no escopo system

### DIFF
--- a/p3/libs/helpers.lib
+++ b/p3/libs/helpers.lib
@@ -21,13 +21,73 @@ flatpak_in_lib() {
         sleep 2
     fi
 
-    # Add Flathub remote if not exists
-    flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo 
-
-    sudo flatpak remote-add --if-not-exists --system flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    # Add Flathub remote only if it doesn't exist in either scope
+    if ! flatpak_has_remote user flathub && ! flatpak_has_remote system flathub; then
+        # Prefer system-wide remote when available
+        sudo flatpak remote-add --if-not-exists --system flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    fi
 
     touch /tmp/linuxtoys_flatpak_done
     return 0
+}
+
+flatpak_has_remote() {
+    local scope="$1"
+    local remote="$2"
+
+    flatpak remotes --"${scope}" --columns=name 2>/dev/null | grep -qx "$remote"
+}
+
+flatpak_pick_scope() {
+    local remote="$1"
+
+    if [[ -z "$remote" ]]; then
+        echo "user"
+        return 0
+    fi
+
+    if [[ -e "$remote" || "$remote" == *.flatpak || "$remote" == *.flatpakref || "$remote" == *.flatpakrepo ]]; then
+        echo "user"
+        return 0
+    fi
+
+    if flatpak_has_remote user "$remote"; then
+        echo "user"
+    elif flatpak_has_remote system "$remote"; then
+        echo "system"
+    else
+        echo "user"
+    fi
+}
+
+flatpak_install() {
+    local args=()
+    local scope=""
+    local remote=""
+
+    for arg in "$@"; do
+        case "$arg" in
+            --user) scope="user" ;;
+            --system) scope="system" ;;
+            *) args+=("$arg") ;;
+        esac
+    done
+
+    if [[ -z "$scope" ]]; then
+        for arg in "${args[@]}"; do
+            if [[ "$arg" != -* ]]; then
+                remote="$arg"
+                break
+            fi
+        done
+        scope="$(flatpak_pick_scope "$remote")"
+    fi
+
+    if [[ "$scope" == "system" ]]; then
+        sudo flatpak install --system "${args[@]}"
+    else
+        flatpak install --user "${args[@]}"
+    fi
 }
 
 # --- Multilib ---

--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -148,7 +148,7 @@ _install_() {
 _flatpak_() {
     [[ -z "$_flatpaks" ]] && return 0
     for flat in "${_flatpaks[@]}"; do
-        flatpak install --or-update --user --noninteractive flathub "$flat"
+        flatpak_install --or-update --noninteractive flathub "$flat"
     done
     unset _flatpaks
 }

--- a/p3/libs/optimizers.lib
+++ b/p3/libs/optimizers.lib
@@ -157,7 +157,7 @@ EOF
 
 # add video playback with hardware acceleration capabilities to flatpaks
 hwaccel_flat_lib () {
-    flatpak install --or-update --system --noninteractive flathub org.freedesktop.Platform.ffmpeg-full/x86_64/24.08 org.freedesktop.Platform.ffmpeg-full/x86_64/23.08 org.freedesktop.Platform.ffmpeg-full/x86_64/22.08
+    flatpak_install --or-update --system --noninteractive flathub org.freedesktop.Platform.ffmpeg-full/x86_64/24.08 org.freedesktop.Platform.ffmpeg-full/x86_64/23.08 org.freedesktop.Platform.ffmpeg-full/x86_64/22.08
 }
 
 # for intel and nvidia GPUs, fix GTK rendering bugs

--- a/p3/scripts/chat/discord.sh
+++ b/p3/scripts/chat/discord.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.discordapp.Discord
+flatpak_install --or-update --noninteractive flathub com.discordapp.Discord

--- a/p3/scripts/chat/msteams.sh
+++ b/p3/scripts/chat/msteams.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.github.IsmaelMartinez.teams_for_linux
+flatpak_install --or-update --noninteractive flathub com.github.IsmaelMartinez.teams_for_linux

--- a/p3/scripts/chat/signal_desktop.sh
+++ b/p3/scripts/chat/signal_desktop.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.signal.Signal
+flatpak_install --or-update --noninteractive flathub org.signal.Signal
 

--- a/p3/scripts/chat/slack.sh
+++ b/p3/scripts/chat/slack.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.slack.Slack
+flatpak_install --or-update --noninteractive flathub com.slack.Slack

--- a/p3/scripts/chat/telegram.sh
+++ b/p3/scripts/chat/telegram.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.telegram.desktop
+flatpak_install --or-update --noninteractive flathub org.telegram.desktop
 

--- a/p3/scripts/chat/zapzap.sh
+++ b/p3/scripts/chat/zapzap.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.rtosta.zapzap
+flatpak_install --or-update --noninteractive flathub com.rtosta.zapzap
 

--- a/p3/scripts/devs/httpie.sh
+++ b/p3/scripts/devs/httpie.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --user --or-update --noninteractive flathub io.httpie.Httpie
+flatpak_install --or-update --noninteractive flathub io.httpie.Httpie
 zeninf "$msg018"

--- a/p3/scripts/devs/ides/androidstd.sh
+++ b/p3/scripts/devs/ides/androidstd.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --user --or-update --noninteractive flathub com.google.AndroidStudio
+flatpak_install --or-update --noninteractive flathub com.google.AndroidStudio
 zeninf "$msg018"

--- a/p3/scripts/devs/ides/codium.sh
+++ b/p3/scripts/devs/ides/codium.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --user --or-update --noninteractive flathub com.vscodium.codium
+flatpak_install --or-update --noninteractive flathub com.vscodium.codium
 zeninf "$msg018"

--- a/p3/scripts/devs/ides/zed.sh
+++ b/p3/scripts/devs/ides/zed.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub dev.zed.Zed
+flatpak_install --or-update --noninteractive flathub dev.zed.Zed
 

--- a/p3/scripts/devs/insomnia.sh
+++ b/p3/scripts/devs/insomnia.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --user --or-update --noninteractive flathub rest.insomnia.Insomnia
+flatpak_install --or-update --noninteractive flathub rest.insomnia.Insomnia
 zeninf "$msg018"

--- a/p3/scripts/devs/postman.sh
+++ b/p3/scripts/devs/postman.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --user --or-update --noninteractive flathub com.getpostman.Postman
+flatpak_install --or-update --noninteractive flathub com.getpostman.Postman
 zeninf "$msg018"

--- a/p3/scripts/drivers/optimusui.sh
+++ b/p3/scripts/drivers/optimusui.sh
@@ -21,5 +21,5 @@ elif is_suse; then
 fi
 _install_
 flatpak_in_lib
-flatpak install --or-update --system --noninteractive de.z_ray.OptimusUI
+flatpak_install --or-update --system --noninteractive de.z_ray.OptimusUI
 zeninf "$msg018"

--- a/p3/scripts/edu/endlesskey.sh
+++ b/p3/scripts/edu/endlesskey.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.endlessos.Key
+flatpak_install --or-update --noninteractive flathub org.endlessos.Key

--- a/p3/scripts/edu/gcompris.sh
+++ b/p3/scripts/edu/gcompris.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.kde.gcompris
+flatpak_install --or-update --noninteractive flathub org.kde.gcompris

--- a/p3/scripts/edu/geogebra.sh
+++ b/p3/scripts/edu/geogebra.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.geogebra.GeoGebra
+flatpak_install --or-update --noninteractive flathub org.geogebra.GeoGebra

--- a/p3/scripts/edu/kalzium.sh
+++ b/p3/scripts/edu/kalzium.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.kde.kalzium
+flatpak_install --or-update --noninteractive flathub org.kde.kalzium

--- a/p3/scripts/edu/kolibri.sh
+++ b/p3/scripts/edu/kolibri.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.learningequality.Kolibri
+flatpak_install --or-update --noninteractive flathub org.learningequality.Kolibri

--- a/p3/scripts/edu/stellarium.sh
+++ b/p3/scripts/edu/stellarium.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.stellarium.Stellarium
+flatpak_install --or-update --noninteractive flathub org.stellarium.Stellarium

--- a/p3/scripts/extra/lsw.sh
+++ b/p3/scripts/extra/lsw.sh
@@ -149,7 +149,7 @@ if [ -e /dev/kvm ]; then
             docker_in
             # stage 2: freeRDP
             flatpak_in_lib
-            flatpak install -y --user --noninteractive flathub com.freerdp.FreeRDP
+            flatpak_install -y --noninteractive flathub com.freerdp.FreeRDP
             # enable iptables kernel module
             echo -e "ip_tables\niptable_nat" | sudo tee /etc/modules-load.d/iptables.conf
             # get latest winboat release

--- a/p3/scripts/game/faugus.sh
+++ b/p3/scripts/game/faugus.sh
@@ -13,7 +13,7 @@ source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 if is_debian || is_ubuntu || is_ostree || is_suse; then
     flatpak_in_lib
-    flatpak install --user --noninteractive flathub io.github.Faugus.faugus-launcher
+    flatpak_install --noninteractive flathub io.github.Faugus.faugus-launcher
     sudo_rq
     # apply overrides for Steam compatibility
     sudo flatpak override io.github.Faugus.faugus-launcher --filesystem=~/.var/app/com.valvesoftware.Steam/.steam/steam/userdata/

--- a/p3/scripts/game/gfn.sh
+++ b/p3/scripts/game/gfn.sh
@@ -13,7 +13,7 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.freedesktop.Sdk//24.08
+flatpak_install --or-update --noninteractive flathub org.freedesktop.Sdk//24.08
 flatpak remote-add --user --if-not-exists GeForceNOW https://international.download.nvidia.com/GFNLinux/flatpak/geforcenow.flatpakrepo
-flatpak install --or-update --user --noninteractive GeForceNOW com.nvidia.geforcenow
+flatpak_install --or-update --noninteractive GeForceNOW com.nvidia.geforcenow
 flatpak override --user --nosocket=wayland com.nvidia.geforcenow

--- a/p3/scripts/game/goverlay.sh
+++ b/p3/scripts/game/goverlay.sh
@@ -16,5 +16,5 @@ sudo_rq
 _packages=(mangohud goverlay) && _install_
 if command -v flatpak &> /dev/null; then
     flatpak_in_lib
-    flatpak install --or-update --user --noninteractive flathub com.valvesoftware.Steam.VulkanLayer.MangoHud/x86_64/stable org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08
+    flatpak_install --or-update --noninteractive flathub com.valvesoftware.Steam.VulkanLayer.MangoHud/x86_64/stable org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08
 fi

--- a/p3/scripts/game/gscope.sh
+++ b/p3/scripts/game/gscope.sh
@@ -37,5 +37,5 @@ fi
 # install flatpak runtime as well
 if command -v flatpak >/dev/null 2>&1; then
     flatpak_in_lib
-    flatpak install --or-update --user --noninteractive flathub org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08
+    flatpak_install --or-update --noninteractive flathub org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08
 fi

--- a/p3/scripts/game/gsr.sh
+++ b/p3/scripts/game/gsr.sh
@@ -16,4 +16,4 @@ source "$SCRIPT_DIR/libs/helpers.lib"
 # request sudo, GSR needs to be installed on system level
 sudo_rq
 flatpak_in_lib
-flatpak install --or-update --system --noninteractive flathub com.dec05eba.gpu_screen_recorder
+flatpak_install --or-update --system --noninteractive flathub com.dec05eba.gpu_screen_recorder

--- a/p3/scripts/game/hgl.sh
+++ b/p3/scripts/game/hgl.sh
@@ -55,7 +55,7 @@ elif [ "$ID" == "arch" ] || [ "$ID" == "cachyos" ] || [[ "$ID_LIKE" =~ "arch" ]]
     zeninf "$msg281" 
 else
     flatpak_in_lib
-    flatpak install --or-update --user --noninteractive flathub com.heroicgameslauncher.hgl
+    flatpak_install --or-update --noninteractive flathub com.heroicgameslauncher.hgl
 fi
 unset tag
 unset ver

--- a/p3/scripts/game/lsfg.sh
+++ b/p3/scripts/game/lsfg.sh
@@ -54,8 +54,8 @@ else
         if command -v flatpak &> /dev/null; then
             wget https://github.com/PancakeTAS/lsfg-vk/releases/download/${tag}/org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak
             wget https://github.com/PancakeTAS/lsfg-vk/releases/download/${tag}/org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
-            flatpak install --reinstall --user -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak 
-            flatpak install --reinstall --user -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
+            flatpak_install --reinstall -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak
+            flatpak_install --reinstall -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
             rm org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak
             rm org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
             # update overrides if new additions are in this script
@@ -107,8 +107,8 @@ else
         if command -v flatpak &> /dev/null; then
             wget https://github.com/PancakeTAS/lsfg-vk/releases/download/${tag}/org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak
             wget https://github.com/PancakeTAS/lsfg-vk/releases/download/${tag}/org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
-            flatpak install --reinstall --user -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak 
-            flatpak install --reinstall --user -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
+            flatpak_install --reinstall -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak
+            flatpak_install --reinstall -y ./org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
             rm org.freedesktop.Platform.VulkanLayer.lsfg_vk_23.08.flatpak
             rm org.freedesktop.Platform.VulkanLayer.lsfg_vk_24.08.flatpak
             flatapps=(com.usebottles.bottles net.lutris.Lutris com.valvesoftware.Steam com.heroicgameslauncher.hgl org.prismlauncher.PrismLauncher com.stremio.Stremio at.vintagestory.VintageStory org.vinegarhq.Sober)

--- a/p3/scripts/game/lutris.sh
+++ b/p3/scripts/game/lutris.sh
@@ -26,5 +26,5 @@ elif [ "$ID" == "arch" ] || [ "$ID" == "cachyos" ] || [[ "$ID_LIKE" =~ "arch" ]]
 else
     # use flatpak for all others, since native install usually only works well on Fedora and Arch
     flatpak_in_lib
-    flatpak install --or-update --user --noninteractive flathub net.lutris.Lutris
+    flatpak_install --or-update --noninteractive flathub net.lutris.Lutris
 fi

--- a/p3/scripts/game/mcbe.sh
+++ b/p3/scripts/game/mcbe.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.mrarm.mcpelauncher
+flatpak_install --or-update --noninteractive flathub io.mrarm.mcpelauncher

--- a/p3/scripts/game/mgjuice.sh
+++ b/p3/scripts/game/mgjuice.sh
@@ -15,5 +15,5 @@ source "$SCRIPT_DIR/libs/helpers.lib"
 sudo_rq
 _packages=(mangohud) && _install_
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.valvesoftware.Steam.VulkanLayer.MangoHud/x86_64/stable org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08
-flatpak install --or-update --user --noninteractive flathub io.github.radiolamp.mangojuice
+flatpak_install --or-update --noninteractive flathub com.valvesoftware.Steam.VulkanLayer.MangoHud/x86_64/stable org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08
+flatpak_install --or-update --noninteractive flathub io.github.radiolamp.mangojuice

--- a/p3/scripts/game/moonlight.sh
+++ b/p3/scripts/game/moonlight.sh
@@ -12,4 +12,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.moonlight_stream.Moonlight
+flatpak_install --or-update --noninteractive flathub com.moonlight_stream.Moonlight

--- a/p3/scripts/game/osu.sh
+++ b/p3/scripts/game/osu.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub sh.ppy.osu
+flatpak_install --or-update --noninteractive flathub sh.ppy.osu

--- a/p3/scripts/game/prism.sh
+++ b/p3/scripts/game/prism.sh
@@ -11,5 +11,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive org.prismlauncher.PrismLauncher
+flatpak_install --or-update --noninteractive org.prismlauncher.PrismLauncher
 zeninf "$msg018"

--- a/p3/scripts/game/protonplus.sh
+++ b/p3/scripts/game/protonplus.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.vysp3r.ProtonPlus
+flatpak_install --or-update --noninteractive flathub com.vysp3r.ProtonPlus

--- a/p3/scripts/game/ptricks.sh
+++ b/p3/scripts/game/ptricks.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.github.Matoking.protontricks
+flatpak_install --or-update --noninteractive flathub com.github.Matoking.protontricks

--- a/p3/scripts/game/pup.sh
+++ b/p3/scripts/game/pup.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub net.davidotek.pupgui2
+flatpak_install --or-update --noninteractive flathub net.davidotek.pupgui2

--- a/p3/scripts/game/sober.sh
+++ b/p3/scripts/game/sober.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.vinegarhq.Sober
+flatpak_install --or-update --noninteractive flathub org.vinegarhq.Sober

--- a/p3/scripts/game/steam.sh
+++ b/p3/scripts/game/steam.sh
@@ -27,7 +27,7 @@ else
     # use flatpak for all others, since native install usually only works well on Fedora and Arch
     sudo_rq
     flatpak_in_lib
-    flatpak install --or-update --user --noninteractive flathub com.valvesoftware.Steam
+    flatpak_install --or-update --noninteractive flathub com.valvesoftware.Steam
     _packages=(steam-devices)
     _install_
 fi

--- a/p3/scripts/game/sunshine.sh
+++ b/p3/scripts/game/sunshine.sh
@@ -13,5 +13,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub dev.lizardbyte.app.Sunshine
+flatpak_install --or-update --noninteractive flathub dev.lizardbyte.app.Sunshine
 flatpak run --command=additional-install.sh dev.lizardbyte.app.Sunshine

--- a/p3/scripts/game/vinegar.sh
+++ b/p3/scripts/game/vinegar.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.vinegarhq.Vinegar
+flatpak_install --or-update --noninteractive flathub org.vinegarhq.Vinegar

--- a/p3/scripts/game/wivrn.sh
+++ b/p3/scripts/game/wivrn.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.wivrn.wivrn
+flatpak_install --or-update --noninteractive flathub io.github.wivrn.wivrn

--- a/p3/scripts/office/anydesk.sh
+++ b/p3/scripts/office/anydesk.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.anydesk.Anydesk
+flatpak_install --or-update --noninteractive flathub com.anydesk.Anydesk

--- a/p3/scripts/office/audacity.sh
+++ b/p3/scripts/office/audacity.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.audacityteam.Audacity
+flatpak_install --or-update --noninteractive flathub org.audacityteam.Audacity

--- a/p3/scripts/office/blender.sh
+++ b/p3/scripts/office/blender.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.blender.Blender
+flatpak_install --or-update --noninteractive flathub org.blender.Blender

--- a/p3/scripts/office/chrome.sh
+++ b/p3/scripts/office/chrome.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.google.Chrome
+flatpak_install --or-update --noninteractive flathub com.google.Chrome

--- a/p3/scripts/office/cohesion.sh
+++ b/p3/scripts/office/cohesion.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.brunofin.Cohesion
+flatpak_install --or-update --noninteractive flathub io.github.brunofin.Cohesion

--- a/p3/scripts/office/darktable.sh
+++ b/p3/scripts/office/darktable.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.darktable.Darktable
+flatpak_install --or-update --noninteractive flathub org.darktable.Darktable

--- a/p3/scripts/office/foliate.sh
+++ b/p3/scripts/office/foliate.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.github.johnfactotum.Foliate
+flatpak_install --or-update --noninteractive flathub com.github.johnfactotum.Foliate

--- a/p3/scripts/office/freecad.sh
+++ b/p3/scripts/office/freecad.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.freecad.FreeCAD
+flatpak_install --or-update --noninteractive flathub org.freecad.FreeCAD

--- a/p3/scripts/office/gimp.sh
+++ b/p3/scripts/office/gimp.sh
@@ -13,7 +13,7 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.gimp.GIMP
+flatpak_install --or-update --noninteractive flathub org.gimp.GIMP
 if zenity --question --text "$msg253" --width 360 --height 300; then
     zeninf "$msg254"
     flatpak run org.gimp.GIMP --batch-interpreter=plug-in-script-fu-eval -b "(gimp-quit 0)" && {

--- a/p3/scripts/office/inkscape.sh
+++ b/p3/scripts/office/inkscape.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.inkscape.Inkscape
+flatpak_install --or-update --noninteractive flathub org.inkscape.Inkscape

--- a/p3/scripts/office/kdenlive.sh
+++ b/p3/scripts/office/kdenlive.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.kde.kdenlive
+flatpak_install --or-update --noninteractive flathub org.kde.kdenlive

--- a/p3/scripts/office/kicad.sh
+++ b/p3/scripts/office/kicad.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.kicad.KiCad
+flatpak_install --or-update --noninteractive flathub org.kicad.KiCad

--- a/p3/scripts/office/krita.sh
+++ b/p3/scripts/office/krita.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.kde.krita
+flatpak_install --or-update --noninteractive flathub org.kde.krita

--- a/p3/scripts/office/libreoffice.sh
+++ b/p3/scripts/office/libreoffice.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.libreoffice.LibreOffice
+flatpak_install --or-update --noninteractive flathub org.libreoffice.LibreOffice

--- a/p3/scripts/office/obsidian.sh
+++ b/p3/scripts/office/obsidian.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub md.obsidian.Obsidian
+flatpak_install --or-update --noninteractive flathub md.obsidian.Obsidian

--- a/p3/scripts/office/onlyoffice.sh
+++ b/p3/scripts/office/onlyoffice.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.onlyoffice.desktopeditors
+flatpak_install --or-update --noninteractive flathub org.onlyoffice.desktopeditors

--- a/p3/scripts/office/pinta.sh
+++ b/p3/scripts/office/pinta.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.github.PintaProject.Pinta
+flatpak_install --or-update --noninteractive flathub com.github.PintaProject.Pinta

--- a/p3/scripts/office/zen.sh
+++ b/p3/scripts/office/zen.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub app.zen_browser.zen
+flatpak_install --or-update --noninteractive flathub app.zen_browser.zen

--- a/p3/scripts/sysadm/cockpit-client.sh
+++ b/p3/scripts/sysadm/cockpit-client.sh
@@ -13,5 +13,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.cockpit_project.CockpitClient
+flatpak_install --or-update --noninteractive flathub org.cockpit_project.CockpitClient
 zeninf "$msg018"

--- a/p3/scripts/sysadm/cpu-x.sh
+++ b/p3/scripts/sysadm/cpu-x.sh
@@ -10,6 +10,6 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.thetumultuousunicornofdarkness.cpu-x
+flatpak_install --or-update --noninteractive flathub io.github.thetumultuousunicornofdarkness.cpu-x
 zeninf "$msg018"
 

--- a/p3/scripts/sysadm/termius.sh
+++ b/p3/scripts/sysadm/termius.sh
@@ -13,5 +13,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.termius.Termius
+flatpak_install --or-update --noninteractive flathub com.termius.Termius
 zeninf "$msg018"

--- a/p3/scripts/utils/bazaar.sh
+++ b/p3/scripts/utils/bazaar.sh
@@ -13,5 +13,5 @@ source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 sudo_rq
 flatpak_in_lib
-sudo flatpak install --or-update --system --noninteractive flathub io.github.kolunmi.Bazaar
+flatpak_install --or-update --system --noninteractive flathub io.github.kolunmi.Bazaar
 zeninf "$msg018"

--- a/p3/scripts/utils/bottles.sh
+++ b/p3/scripts/utils/bottles.sh
@@ -10,4 +10,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.usebottles.bottles
+flatpak_install --or-update --noninteractive flathub com.usebottles.bottles

--- a/p3/scripts/utils/boxadv.sh
+++ b/p3/scripts/utils/boxadv.sh
@@ -34,5 +34,5 @@ else
     distrobox-assemble create --file https://raw.githubusercontent.com/pedrohqb/distrobox-adv-br/refs/heads/main/distrobox-adv-br
 fi
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.ranfdev.DistroShelf
+flatpak_install --or-update --noninteractive flathub com.ranfdev.DistroShelf
 zeninf "$msg018"

--- a/p3/scripts/utils/distroshelf.sh
+++ b/p3/scripts/utils/distroshelf.sh
@@ -17,4 +17,4 @@ fi
 _packages=(podman distrobox)
 _install_
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.ranfdev.DistroShelf
+flatpak_install --or-update --noninteractive flathub com.ranfdev.DistroShelf

--- a/p3/scripts/utils/efx.sh
+++ b/p3/scripts/utils/efx.sh
@@ -12,4 +12,4 @@ source "$SCRIPT_DIR/libs/helpers.lib"
 # request sudo, EasyEffects needs to be installed on system level
 sudo_rq
 flatpak_in_lib
-flatpak install --or-update --system --noninteractive flathub com.github.wwmm.easyeffects
+flatpak_install --or-update --system --noninteractive flathub com.github.wwmm.easyeffects

--- a/p3/scripts/utils/extman.sh
+++ b/p3/scripts/utils/extman.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.mattjakeman.ExtensionManager
+flatpak_install --or-update --noninteractive flathub com.mattjakeman.ExtensionManager
 zeninf "$msg018"

--- a/p3/scripts/utils/flatseal.sh
+++ b/p3/scripts/utils/flatseal.sh
@@ -10,4 +10,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.github.tchx84.Flatseal
+flatpak_install --or-update --noninteractive flathub com.github.tchx84.Flatseal

--- a/p3/scripts/utils/gearlever.sh
+++ b/p3/scripts/utils/gearlever.sh
@@ -10,4 +10,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub it.mijorus.gearlever
+flatpak_install --or-update --noninteractive flathub it.mijorus.gearlever

--- a/p3/scripts/utils/handbrake.sh
+++ b/p3/scripts/utils/handbrake.sh
@@ -10,4 +10,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub fr.handbrake.ghb
+flatpak_install --or-update --noninteractive flathub fr.handbrake.ghb

--- a/p3/scripts/utils/lact.sh
+++ b/p3/scripts/utils/lact.sh
@@ -12,4 +12,4 @@ source "$SCRIPT_DIR/libs/helpers.lib"
 # request sudo - LACT requires system level installation
 sudo_rq
 flatpak_in_lib
-flatpak install --or-update --system --noninteractive flathub io.github.ilya_zlobintsev.LACT
+flatpak_install --or-update --system --noninteractive flathub io.github.ilya_zlobintsev.LACT

--- a/p3/scripts/utils/mctl.sh
+++ b/p3/scripts/utils/mctl.sh
@@ -11,4 +11,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.missioncenter.MissionCenter
+flatpak_install --or-update --noninteractive flathub io.missioncenter.MissionCenter

--- a/p3/scripts/utils/obs.sh
+++ b/p3/scripts/utils/obs.sh
@@ -29,7 +29,7 @@ obs_pipe () {
     rm -rf obspipe
 }
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.obsproject.Studio
+flatpak_install --or-update --noninteractive flathub com.obsproject.Studio
 sleep 1
 sudo_rq
 # check dependency for Pipewire Audio Capture plugin and xwayland

--- a/p3/scripts/utils/peazip.sh
+++ b/p3/scripts/utils/peazip.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.peazip.PeaZip
+flatpak_install --or-update --noninteractive flathub io.github.peazip.PeaZip
 

--- a/p3/scripts/utils/peripherals/oprgb.sh
+++ b/p3/scripts/utils/peripherals/oprgb.sh
@@ -12,7 +12,7 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.openrgb.OpenRGB
+flatpak_install --or-update --noninteractive flathub org.openrgb.OpenRGB
 if [[ "$ID_LIKE" =~ (rhel|fedora) ]] || [ "$ID" == "fedora" ]; then
     sudo_rq
     rpmfusion_chk

--- a/p3/scripts/utils/peripherals/oprzr.sh
+++ b/p3/scripts/utils/peripherals/oprzr.sh
@@ -61,5 +61,5 @@ else
     sudo gpasswd -a $USER plugdev
 fi
 flatpak_in_lib
-flatpak install -y --system --noninteractive flathub app.polychromatic.controller
+flatpak_install -y --system --noninteractive flathub app.polychromatic.controller
 zeninf "$msg036"

--- a/p3/scripts/utils/peripherals/piper.sh
+++ b/p3/scripts/utils/peripherals/piper.sh
@@ -24,5 +24,5 @@ elif is_suse; then
 fi
 _install_
 flatpak_in_lib
-flatpak install -y --system --noninteractive flathub org.freedesktop.Piper
+flatpak_install -y --system --noninteractive flathub org.freedesktop.Piper
 zeninf "$finishmsg"

--- a/p3/scripts/utils/peripherals/sc.sh
+++ b/p3/scripts/utils/peripherals/sc.sh
@@ -12,5 +12,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.core447.StreamController
+flatpak_install --or-update --noninteractive flathub com.core447.StreamController
 zeninf "$msg018"

--- a/p3/scripts/utils/peripherals/steer.sh
+++ b/p3/scripts/utils/peripherals/steer.sh
@@ -14,7 +14,7 @@ source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 sudo_rq
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.berarma.Oversteer
+flatpak_install --or-update --noninteractive flathub io.github.berarma.Oversteer
 sudo wget https://github.com/berarma/oversteer/raw/refs/heads/master/data/udev/99-fanatec-wheel-perms.rules -P /etc/udev/rules.d
 sudo wget https://github.com/berarma/oversteer/raw/refs/heads/master/data/udev/99-logitech-wheel-perms.rules -P /etc/udev/rules.d
 sudo wget https://github.com/berarma/oversteer/raw/refs/heads/master/data/udev/99-thrustmaster-wheel-perms.rules -P /etc/udev/rules.d

--- a/p3/scripts/utils/pika.sh
+++ b/p3/scripts/utils/pika.sh
@@ -11,5 +11,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.gnome.World.PikaBackup
+flatpak_install --or-update --noninteractive flathub org.gnome.World.PikaBackup
 zeninf "$msg018"

--- a/p3/scripts/utils/privacy/bitwarden.sh
+++ b/p3/scripts/utils/privacy/bitwarden.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.bitwarden.desktop
+flatpak_install --or-update --noninteractive flathub com.bitwarden.desktop
 

--- a/p3/scripts/utils/privacy/brave.sh
+++ b/p3/scripts/utils/privacy/brave.sh
@@ -11,5 +11,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.brave.Browser
+flatpak_install --or-update --noninteractive flathub com.brave.Browser
 zeninf "$msg018"

--- a/p3/scripts/utils/privacy/cryptomator.sh
+++ b/p3/scripts/utils/privacy/cryptomator.sh
@@ -12,4 +12,4 @@ source "$SCRIPT_DIR/libs/helpers.lib"
 _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.cryptomator.Cryptomator
+flatpak_install --or-update --noninteractive flathub org.cryptomator.Cryptomator

--- a/p3/scripts/utils/privacy/keepassxc.sh
+++ b/p3/scripts/utils/privacy/keepassxc.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.keepassxc.KeePassXC
+flatpak_install --or-update --noninteractive flathub org.keepassxc.KeePassXC
 

--- a/p3/scripts/utils/privacy/librewolf.sh
+++ b/p3/scripts/utils/privacy/librewolf.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.gitlab.librewolf-community
+flatpak_install --or-update --noninteractive flathub io.gitlab.librewolf-community

--- a/p3/scripts/utils/privacy/logseq.sh
+++ b/p3/scripts/utils/privacy/logseq.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.logseq.Logseq
+flatpak_install --or-update --noninteractive flathub com.logseq.Logseq

--- a/p3/scripts/utils/privacy/mullvad-browser.sh
+++ b/p3/scripts/utils/privacy/mullvad-browser.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub net.mullvad.MullvadBrowser
+flatpak_install --or-update --noninteractive flathub net.mullvad.MullvadBrowser

--- a/p3/scripts/utils/privacy/proton-vpn.sh
+++ b/p3/scripts/utils/privacy/proton-vpn.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.protonvpn.www
+flatpak_install --or-update --noninteractive flathub com.protonvpn.www

--- a/p3/scripts/utils/privacy/sirikali.sh
+++ b/p3/scripts/utils/privacy/sirikali.sh
@@ -12,4 +12,4 @@ source "$SCRIPT_DIR/libs/helpers.lib"
 _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.mhogomchungu.sirikali
+flatpak_install --or-update --noninteractive flathub io.github.mhogomchungu.sirikali

--- a/p3/scripts/utils/privacy/surfshark-vpn.sh
+++ b/p3/scripts/utils/privacy/surfshark-vpn.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.surfshark.Surfshark
+flatpak_install --or-update --noninteractive flathub com.surfshark.Surfshark

--- a/p3/scripts/utils/privacy/ungoogled-chromium.sh
+++ b/p3/scripts/utils/privacy/ungoogled-chromium.sh
@@ -13,4 +13,4 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.ungoogled_software.ungoogled_chromium
+flatpak_install --or-update --noninteractive flathub io.github.ungoogled_software.ungoogled_chromium

--- a/p3/scripts/utils/qpw.sh
+++ b/p3/scripts/utils/qpw.sh
@@ -10,4 +10,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub org.rncbc.qpwgraph
+flatpak_install --or-update --noninteractive flathub org.rncbc.qpwgraph

--- a/p3/scripts/utils/rclone_ui.sh
+++ b/p3/scripts/utils/rclone_ui.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub com.rcloneui.RcloneUI
+flatpak_install --or-update --noninteractive flathub com.rcloneui.RcloneUI
 

--- a/p3/scripts/utils/s3drive.sh
+++ b/p3/scripts/utils/s3drive.sh
@@ -10,5 +10,5 @@ _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.kapsa.drive
+flatpak_install --or-update --noninteractive flathub io.kapsa.drive
 

--- a/p3/scripts/utils/warehouse.sh
+++ b/p3/scripts/utils/warehouse.sh
@@ -10,4 +10,4 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 source "$SCRIPT_DIR/libs/helpers.lib"
 flatpak_in_lib
-flatpak install --or-update --user --noninteractive flathub io.github.flattool.Warehouse
+flatpak_install --or-update --noninteractive flathub io.github.flattool.Warehouse


### PR DESCRIPTION
## Contexto
No Zorin OS o remote do Flathub costuma existir apenas em `system`. O LinuxToys tentava instalar Flatpaks assumindo `--user` e, quando o remote `user` não existia, ocorria erro. Em alguns casos, o script criava um `flathub` em `user`, o que é indesejado para quem mantém o Flathub apenas em `system`.

## O que foi corrigido
- A detecção de remotes agora verifica `user` e `system` antes de adicionar o Flathub.
- Quando o Flathub já existe em `system`, o LinuxToys usa esse remote sem criar um `user`.
- As instalações Flatpak passaram a usar um helper (`flatpak_install`) que escolhe o escopo correto automaticamente.

## Impacto
- Sistemas que já usam `user` continuam funcionando como antes.
- Sistemas que usam `system` (ex.: Zorin) deixam de falhar e não criam remotes indesejados.

## Testes
- `export SCRIPT_DIR="$PWD/p3"`
- `bash p3/scripts/utils/qpw.sh`
- `flatpak list --system | rg -i qpwgraph`
