### PR TITLE
Fix: DaVinci Resolve FFmpeg Plugin Installation (Compile from Source)

### DIFF
--- a/p3/scripts/extra/resolvehw.sh
+++ b/p3/scripts/extra/resolvehw.sh
@@ -11,39 +11,53 @@ source "$SCRIPT_DIR/libs/linuxtoys.lib"
 _lang_
 source "$SCRIPT_DIR/libs/lang/${langfile}.lib"
 # detect GPU if Intel
+# detect GPU if Intel
 if lspci | grep -E "VGA|3D" | grep -i "Intel" > /dev/null; then
     GPU="Intel"
 fi
-# Get the latest release URL from GitHub API
-GITHUB_API="https://api.github.com/repos/EdvinNilsson/ffmpeg_encoder_plugin/releases/latest"
-LATEST_RELEASE=$(curl -s "$GITHUB_API" | grep '"download_url"' | grep 'ffmpeg_encoder_plugin.dvcp.bundle.zip' | head -1 | cut -d'"' -f4)
-if [ -z "$LATEST_RELEASE" ]; then
-    # Fallback: try to construct URL from release tag
-    RELEASE_TAG=$(curl -s "$GITHUB_API" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
-    if [ -n "$RELEASE_TAG" ]; then
-        LATEST_RELEASE="https://github.com/EdvinNilsson/ffmpeg_encoder_plugin/releases/download/${RELEASE_TAG}/ffmpeg_encoder_plugin.dvcp.bundle.zip"
+
+# Install build dependencies
+if is_fedora || is_ostree; then
+    rpmfusion_chk
+    _packages=(cmake gcc-c++ ffmpeg-devel git make)
+    if [ "$GPU" = "Intel" ]; then
+        _packages+=(intel-media-driver intel-vpl-gpu-rt)
     fi
-fi
-if [ -n "$LATEST_RELEASE" ]; then
-    cd $HOME
-    # Download and execute the install.sh script
-    wget "$LATEST_RELEASE"
-    unzip ffmpeg_encoder_plugin.dvcp.bundle.zip -d /opt/resolve/IOPlugins/
-else
-    fatal "Cannot find ffmpeg_encoder_plugin.dvcp.bundle.zip in the latest release"
-fi
-if [ "$GPU" = "Intel" ]; then
-    if is_fedora || is_ostree; then
-        rpmfusion_chk
-        _packages=(intel-media-driver intel-vpl-gpu-rt)
-        _install_
-        sudo dnf swap --allowerasing ffmpeg-free ffmpeg -y
-    elif is_ubuntu || is_debian; then
-        _packages=(intel-media-driver ffmpeg)
-        _install_
-    elif is_arch || is_cachy; then
-        _packages=(intel-media-driver vpl-gpu-rt ffmpeg-full)
-        _install_
+    _install_
+elif is_ubuntu || is_debian; then
+    _packages=(build-essential cmake libavcodec-dev libavformat-dev libavutil-dev libswscale-dev git make)
+    if [ "$GPU" = "Intel" ]; then
+        _packages+=(intel-media-driver)
     fi
+    _install_
+elif is_arch || is_cachy; then
+    _packages=(cmake ffmpeg git make base-devel)
+    if [ "$GPU" = "Intel" ]; then
+        _packages+=(intel-media-driver vpl-gpu-rt)
+    fi
+    _install_
 fi
+
+# Clone and build
+cd $HOME
+if [ -d "ffmpeg_encoder_plugin" ]; then
+    rm -rf ffmpeg_encoder_plugin
+fi
+git clone https://github.com/EdvinNilsson/ffmpeg_encoder_plugin
+cd ffmpeg_encoder_plugin
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+make
+
+# Install
+# Directory structure for Linux-x86-64
+PLUGIN_DIR="/opt/resolve/IOPlugins/ffmpeg_encoder_plugin.dvcp.bundle/Contents/Linux-x86-64"
+sudo mkdir -p "$PLUGIN_DIR"
+sudo cp ffmpeg_encoder_plugin.dvcp "$PLUGIN_DIR/"
+
+# Cleanup
+cd $HOME
+rm -rf ffmpeg_encoder_plugin
+zeninf "DaVinci Resolve FFmpeg Plugin installed successfully!"
 


### PR DESCRIPTION
# Description of Changes

This PR updates the [p3/scripts/extra/resolvehw.sh](cci:7://file:///media/panda-storage/Projects/satodu/linuxtoys/p3/scripts/extra/resolvehw.sh:0:0-0:0) script to compile the [ffmpeg_encoder_plugin](https://github.com/EdvinNilsson/ffmpeg_encoder_plugin) from source instead of downloading a pre-built binary.
The previous binary download method was failing on CachyOS (and potentially other Arch-based distributions). Compiling from source ensures better compatibility across different environments.

Specific changes:
- Added logic to install build dependencies (`cmake`, `make`, `git`, `ffmpeg`, etc.) for Fedora/OSTree, Debian/Ubuntu, and Arch/CachyOS.
- Implemented `git clone` and build process (`cmake .. && make`).
- Updated the installation path to correct location for the compiled plugin (`/opt/resolve/IOPlugins/ffmpeg_encoder_plugin.dvcp.bundle/Contents/Linux-x86-64/`).
- Removed the GitHub API binary download logic.

## Type of Change
- [x] Bug fix
<!-- - [ ] New feature -->
<!-- - [ ] Documentation -->
