### PR TITLE
fix: capture flatpak stderr and ensure GNOME runtime for tac-writer (#667)

### DIFF
--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -466,8 +466,9 @@ pkg_fromfile () {
            ! flatpak remote-list --user 2>/dev/null | grep -q flathub; then
             flatpak_scope="--system"
         fi
-        flatpak install "$flatpak_scope" --noninteractive "$flatpak_file" 2>/dev/null || \
-        fatal "Failed to install flatpak from file: $flatpak_file"
+        local _flatpak_stderr
+        _flatpak_stderr=$(flatpak install "$flatpak_scope" --noninteractive "$flatpak_file" 2>&1 1>/dev/null) || \
+        fatal "Failed to install flatpak from file: $flatpak_file\nDetails:\n$_flatpak_stderr"
         _append_transmap "pkg file $flatpak_file"
         return 0
     fi

--- a/p3/scripts/edu/tacwriter.sh
+++ b/p3/scripts/edu/tacwriter.sh
@@ -24,6 +24,9 @@ fi
 prep_tmp
 wget "$LATEST_BUNDLE_URL" -O "tac-writer-$LATEST_VERSION.flatpak" || fatal "Failed to download Tac Writer flatpak bundle."
 
+# Ensure required GNOME runtime is available before installing the bundle
+pkg_flat org.gnome.Platform//50
+
 # Install bundle for current user (silent mode; show details only on failure)
 pkg_fromfile "tac-writer-$LATEST_VERSION.flatpak"
 # Write version file so the in-app update checker can compare against GitHub tags


### PR DESCRIPTION
## Problema

Ao instalar bundles `.flatpak` (como o Tac Writer) via LinuxToys, o usuário recebia apenas uma mensagem genérica, sem nenhuma informação sobre o erro real:

```
Failed to install flatpak from file: tac-writer-1.4.4-1.flatpak
```

Isso acontecia porque a função `pkg_fromfile()` suprimia o `stderr` com `2>/dev/null`, impossibilitando o usuário de saber por que a instalação falhou.

## Causa raiz identificada

No caso do Tac Writer, o erro real é:

```
error: The application io.github.narayanls.tacwriter/x86_64/master
requires the runtime org.gnome.Platform/x86_64/50 which was not found
```

O bundle do Tac Writer é compilado contra o `org.gnome.Platform` 50, mas esse runtime não vem pré-instalado em distribuições como o CachyOS. O flatpak não resolve dependências de runtime automaticamente ao instalar um bundle `.flatpak` — ele apenas verifica se o runtime já existe localmente.

## Solução

### 1. Captura do `stderr` em `pkg_fromfile()` (`p3/libs/linuxtoys.lib`)

A função agora captura a saída de erro do flatpak e a inclui na mensagem exibida ao usuário, em vez de suprimi-la:

```diff
-        flatpak install "$flatpak_scope" --noninteractive "$flatpak_file" 2>/dev/null || \
-        fatal "Failed to install flatpak from file: $flatpak_file"
+        local _flatpak_stderr
+        _flatpak_stderr=$(flatpak install "$flatpak_scope" --noninteractive "$flatpak_file" 2>&1 1>/dev/null) || \
+        fatal "Failed to install flatpak from file: $flatpak_file\nDetails:\n$_flatpak_stderr"
```

Agora o usuário vê o erro real (ex: runtime faltando, bundle corrompido, etc.) em vez de uma mensagem genérica.

### 2. Garantia do runtime GNOME 50 no Tac Writer (`p3/scripts/edu/tacwriter.sh`)

Adicionada a instalação do runtime necessário antes do bundle:

```diff
+# Ensure required GNOME runtime is available before installing the bundle
+pkg_flat org.gnome.Platform//50
+
 # Install bundle for current user (silent mode; show details only on failure)
 pkg_fromfile "tac-writer-$LATEST_VERSION.flatpak"
```

Isso previne o erro de runtime faltando no CachyOS e em qualquer outra distribuição que não tenha o GNOME Platform 50 pré-instalado.

## Como foi testado

Reproduzi o erro em um container CachyOS isolado via Podman:

1. Container: `podman run --rm cachyos/cachyos:latest bash`
2. Instalei o flatpak dentro do container com `pacman -Sy flatpak`
3. Adicionei o Flathub como remote
4. Baixei o bundle do Tac Writer dentro do container (`wget` do GitHub)
5. **Teste 1 — Comportamento anterior (`2>/dev/null`)**: reproduziu exatamente o erro relatado — exit code 1, sem nenhuma informação do motivo
6. **Teste 2 — Comportamento com fix (stderr capturado)**: exibiu o erro real:
   ```
   error: The application io.github.narayanls.tacwriter/x86_64/master
   requires the runtime org.gnome.Platform/x86_64/50 which was not found
   ```
7. **Teste 3 — Após instalar o runtime GNOME 50**: `pkg_flat org.gnome.Platform//50` instalou com sucesso, e o bundle do Tac Writer instalou em seguida sem erros

## Arquivos alterados

- `p3/libs/linuxtoys.lib`
- `p3/scripts/edu/tacwriter.sh`

## Issue relacionada

Resolve #667