### PR TITLE
Restore RStudio and update API URL

### DIFF
--- a/p3/scripts/devs/ides/rstudio.sh
+++ b/p3/scripts/devs/ides/rstudio.sh
@@ -4,12 +4,12 @@
 # description: rstudio_desc
 # icon: rstudio.svg
 # repo: https://posit.co/products/open-source/rstudio/
-# compat: none
+# compat: debian, ubuntu, fedora, rhel
 
 # reinstate it when API gets back online: debian, ubuntu, fedora, rhel
 source "$SCRIPT_DIR/libs/helpers.lib"
 _lang_
-_api_stable="https://www.rstudio.com/wp-content/downloads.json"
+_api_stable="https://cdn.posit.co/downloads.json"
 
 _req=$(curl -fsSL "${_api_stable}" | \
     grep -oP '"url": "\K.*download1.*rstudio-[0-9]{4}[^"]*\.(deb|rpm)(?=")')


### PR DESCRIPTION
The downloads.json endpoint has been restored--sorry for the inconvenience!

The original URL works but jumps through a couple of unnecessary redirects, so I've replaced it with the final URL.