### PR TITLE
fix(app): reset reboot-required flag after 'Reboot Later' (#1002)

### DIFF
--- a/p3/app/window.py
+++ b/p3/app/window.py
@@ -710,8 +710,8 @@ class AppWindow(
         """Run checked scripts sequentially."""
         # Check if reboot is required before proceeding
         if self.reboot_required:
-            self._show_reboot_warning_dialog()
-            return
+            if not self._show_reboot_warning_dialog():
+                return
 
         selected_scripts = [
             sh.script_info for sh in self.check_buttons if sh.get_active()
@@ -766,8 +766,8 @@ class AppWindow(
         """Handles script click by creating the dialog and starting the thread."""
         # Check if reboot is required before proceeding
         if self.reboot_required:
-            self._show_reboot_warning_dialog()
-            return
+            if not self._show_reboot_warning_dialog():
+                return
 
         info = widget.info
 
@@ -830,10 +830,19 @@ npx skills add "{source}" -a "{agent}" -g -y --skill "{slug}"
         self.open_term_view([script_info], removable_script_info=script_info, auto_run=True)
 
     def _show_reboot_warning_dialog(self):
-        """Shows a dialog warning that a reboot is required before continuing."""
-        reboot_helper.handle_reboot_requirement(
+        """Shows a dialog warning that a reboot is required before continuing.
+
+        Returns:
+            bool: True if the action may proceed (user chose to continue
+                  without rebooting), False if it should remain blocked.
+        """
+        proceed = not reboot_helper.handle_reboot_requirement(
             self, self.translations, self._close_application
         )
+        if proceed:
+            # User opted to continue without rebooting; no longer block this session
+            self.reboot_required = False
+        return proceed
 
     def _show_cancel_script_warning_dialog(self):
         """

--- a/p3/app/window_items.py
+++ b/p3/app/window_items.py
@@ -208,8 +208,8 @@ class ItemWidgetFactory:
         """Handle remove button click on a script item."""
         # Check if reboot is required before proceeding
         if self.reboot_required:
-            self._show_reboot_warning_dialog()
-            return
+            if not self._show_reboot_warning_dialog():
+                return
 
         # Use a copy without auto_run so the term view waits for the removal flow
         script_copy = dict(item_info)

--- a/p3/app/window_nav.py
+++ b/p3/app/window_nav.py
@@ -10,8 +10,8 @@ class NavCtl:
         """Handles category click, subcategory click, or root script click."""
         # Check if reboot is required before proceeding
         if self.reboot_required:
-            self._show_reboot_warning_dialog()
-            return
+            if not self._show_reboot_warning_dialog():
+                return
 
         info = widget.info
 

--- a/p3/app/window_search.py
+++ b/p3/app/window_search.py
@@ -269,8 +269,8 @@ class SearchCtl:
 
         # Handle regular scripts
         if self.reboot_required:
-            self._show_reboot_warning_dialog()
-            return
+            if not self._show_reboot_warning_dialog():
+                return
 
         # Use VTE-based term_view for execution
         self.open_term_view([item_info], removable_script_info=item_info, auto_run=True)


### PR DESCRIPTION
## Resumo

Corrijo a issue **#1002** — o app pedia reboot repetidamente sem executar script nenhum.

## Problema

Relato do usuário: *"Fui testar em Drivers o Intel e nem executei nem nada, quando saí para testar outra coisa, ele pede para reiniciar o PC."*

O flag `self.reboot_required` (em `window.py`) era setado para `True` quando qualquer script com header `reboot: yes` era executado, e **nunca era resetado**. Os pontos que verificam esse flag (`window.py`, `window_nav.py`, `window_items.py`, `window_search.py`) descartavam o retorno de `handle_reboot_requirement`, então mesmo escolhendo **"Reboot Later"** o app continuava bloqueado — o diálogo de reboot reaparecia em **toda** interação (navegar entre categorias, clicar em script, remover, buscar), mesmo sem executar nada.

## Correção

- `_show_reboot_warning_dialog()` agora **retorna `bool`** e **reseta `self.reboot_required = False`** quando o usuário escolhe "Reboot Later" — a sessão deixa de bloquear a navegação.
- Os 4 pontos de verificação usam `if not self._show_reboot_warning_dialog(): return` — só bloqueiam a ação quando o diálogo **não** foi liberado.
- **Segurança preservada:** fechar/cancelar o diálogo ou escolher "Reboot Now" (com falha no reboot) continua bloqueando a ação e **não** reseta o flag.

## Validação

Testei em container (fedora:44) a lógica do flag em 4 cenários:

1. "Reboot Later" → libera a ação e reseta o flag ✅
2. Cancelar/fechar o diálogo → bloqueia e mantém o flag ✅
3. "Reboot Now" com falha → bloqueia e mantém o flag ✅
4. Flag `False` → navegação passa direto, sem diálogo ✅

Verificação estática: `ast.parse` OK nos 4 arquivos alterados.
