### PR TITLE
fix(drivers): force native arch for build-essential in rtl88x2bu (#1003)

### DIFF
--- a/p3/scripts/drivers/rtl88x2bu-deb.sh
+++ b/p3/scripts/drivers/rtl88x2bu-deb.sh
@@ -11,7 +11,12 @@
 source "$SCRIPT_DIR/libs/linuxtoys.lib"
 _lang_
 sudo_rq
-pkg_install bc git dkms module-assistant build-essential linux-headers-$(uname -r)
+NATIVE_ARCH="$(dpkg --print-architecture)"
+# Remove build-essential:i386 residual que conflita com a instalação amd64 (issue #1003)
+if [ "$NATIVE_ARCH" != "i386" ]; then
+    sudo apt-get remove -y "build-essential:i386" 2>/dev/null || true
+fi
+pkg_install bc git dkms module-assistant "build-essential:${NATIVE_ARCH}" "linux-headers-$(uname -r)"
 
 prep_tmp
 if command -v m-a &>/dev/null; then


### PR DESCRIPTION
## Resumo

Corrijo a issue **#1003** — o script **Realtek WiFi RTL88x2BU** (`p3/scripts/drivers/rtl88x2bu-deb.sh`) falhava no Ubuntu 26.04 com conflito de dependências i386.

## Problema

O log da issue mostrava:

```
build-essential:i386 : Depende: libc6-dev:i386 ... gcc:i386 (>= 4:14.2) ... mas não será instalado
E: Unable to satisfy dependencies. Reached two conflicting assignments:
   1. dkms:amd64=3.2.2-1ubuntu1 é selecionado para instalar
   2. dkms:amd64 Depende gcc ... [no choices]
```

**Causa raiz** (reproduzida em container `ubuntu:26.04`): quando o sistema tem `build-essential:i386` **residual / half-installed** (comum com multiarch i386 habilitado, ex: Steam), o `apt-get install build-essential` sem arquitetura explícita tenta resolver as **duas arquiteturas** (`amd64` + `i386`), que **conflitam entre si** (`build-essential Conflicts build-essential:i386`). No Ubuntu 26.04, o `gcc:i386 >= 4:14.2` ainda não foi publicado → `no choices` → erro fatal.

## Correção

No `rtl88x2bu-deb.sh`, antes de instalar as dependências:

1. Detecta a arquitetura nativa: `NATIVE_ARCH="$(dpkg --print-architecture)"`
2. Se nativa ≠ i386, remove o `build-essential:i386` residual (com `|| true` para não abortar quando i386 não existe)
3. Força a arquitetura nativa no `pkg_install`: `build-essential:${NATIVE_ARCH}`

## Validação

Testei em container `ubuntu:26.04` (podman):

| Teste | Cenário | Resultado |
|---|---|---|
| A | Instalação normal (sem i386) — regressão | ✅ PASS |
| B | `build-essential:i386` half-installed (cenário da issue), com correção | ✅ PASS — remove i386, instala `:amd64` limpo |
| C | Controle: **mesmo estado sem a correção** | ✅ bug reproduzido — `E: Unmet dependencies` (exatamente a falha da issue) |

Observação: a imagem `ubuntu:26.04` não traz `sudo`; o teste realista instala `sudo` junto (pré-requisito do script).
