### PR TITLE
fix(libs): tratar lock do pacman na remoção de pacotes (issue #1014)

### DIFF
--- a/p3/libs/linuxtoys.lib
+++ b/p3/libs/linuxtoys.lib
@@ -387,6 +387,27 @@ move_() {
 }
 
 # Package Management
+
+# Guard against pacman database lock (/var/lib/pacman/db.lck).
+# If pacman is actively running, abort with a clear message. If the lock is
+# stale (no pacman process holding it), remove it and continue.
+pacman_lock_guard () {
+    local PACMAN_ACTIVE=false
+    if [ -f /var/lib/pacman/db.lck ]; then
+        if pgrep -x pacman >/dev/null 2>&1; then
+            PACMAN_ACTIVE=true
+        elif command -v lsof >/dev/null 2>&1 && lsof /var/lib/pacman/db.lck >/dev/null 2>&1; then
+            PACMAN_ACTIVE=true
+        fi
+        if [ "$PACMAN_ACTIVE" = true ]; then
+            fatal "Another package operation is in progress (pacman is running). Please wait for it to finish, or close it manually and retry."
+        else
+            zenwrn "Stale pacman lock detected. Removing /var/lib/pacman/db.lck"
+            sudo rm -f /var/lib/pacman/db.lck || fatal "Failed to remove stale lock. Run: sudo rm /var/lib/pacman/db.lck"
+        fi
+    fi
+}
+
 pkg_exists () {
     pkg_found=()
     pkg_notfound=()
@@ -458,12 +479,9 @@ pkg_install () {
         done
         local to_install_pacman="${_pacman_pkgs[*]}"
         local to_install_paru="${_paru_pkgs[*]}"
-        # check for lock
+        # check for lock before installing
         if [ -n "$to_install_pacman" ]; then
-            [ -f /var/lib/pacman/db.lck ] && {
-                ( pgrep -x pacman >/dev/null 2>&1 && PACMAN_ACTIVE=true || command -v lsof >/dev/null 2>&1 && { lsof /var/lib/pacman/db.lck >/dev/null 2>&1 && PACMAN_ACTIVE=true; }; ) || PACMAN_ACTIVE=false
-                ( [ "$PACMAN_ACTIVE" = true ] && fatal "Another package operation is in progress (pacman is running). Please wait for it to finish, or close it manually and retry."; ) || \
-                ( zenwrn "Stale pacman lock detected. Removing /var/lib/pacman/db.lck" && sudo rm -f /var/lib/pacman/db.lck || fatal "Failed to remove stale lock. Run: sudo rm /var/lib/pacman/db.lck"; ); }
+            pacman_lock_guard
             sudo pacman -S --noconfirm "${_pacman_pkgs[@]}" || fatal "Failed to install $to_install_pacman"
             [[ $_ignore_appends -eq 0 ]] && _append_transmap "pkg $to_install_pacman"
         fi
@@ -592,10 +610,8 @@ pkg_fromfile () {
         { sudo apt-get install -y "${@}" || sudo dpkg -i "${@}"; } || fatal "Failed to install $*"
         _append_transmap "pkg file $*"
     elif is_arch || is_cachy; then
-        [ -f /var/lib/pacman/db.lck ] && {
-            ( pgrep -x pacman >/dev/null 2>&1 && PACMAN_ACTIVE=true || command -v lsof >/dev/null 2>&1 && { lsof /var/lib/pacman/db.lck >/dev/null 2>&1 && PACMAN_ACTIVE=true; }; ) || PACMAN_ACTIVE=false
-            ( [ "$PACMAN_ACTIVE" = true ] && fatal "Another package operation is in progress (pacman is running). Please wait for it to finish, or close it manually and retry."; ) || \
-            ( zenwrn "Stale pacman lock detected. Removing /var/lib/pacman/db.lck" && sudo rm -f /var/lib/pacman/db.lck || fatal "Failed to remove stale lock. Run: sudo rm /var/lib/pacman/db.lck"; ); }
+        # check for lock before installing local package
+        pacman_lock_guard
         if sudo pacman -U "${@}"; then
             _append_transmap "pkg file $*"
         else
@@ -635,6 +651,8 @@ pkg_remove () {
     if is_debian || is_ubuntu; then
         sudo apt-get remove -y --allow-unauthenticated "${pkg_found[@]}" || fatal "Failed to remove packages: $to_remove"
     elif is_arch || is_cachy; then
+        # check for lock before removing (stale lock otherwise aborts pacman -Rsn)
+        pacman_lock_guard
         sudo pacman -Rsn --noconfirm "${pkg_found[@]}" || fatal "Failed to remove packages: $to_remove"
     elif is_ostree; then
         sudo rpm-ostree uninstall "${pkg_found[@]}" || fatal "Failed to remove packages: $to_remove"


### PR DESCRIPTION
Corrige a issue #1014: fluxos de remoção/uninstall no Arch/CachyOS falham quando `/var/lib/pacman/db.lck` está stale ou outra operação do pacman está em execução. Isso quebrava scripts como "Remover Realtek WiFi 8821CE".

## O que mudou

- Adicionado helper `pacman_lock_guard()`
- Reutilizado em `pkg_install`, `pkg_fromfile` e `pkg_remove`
- Se o pacman estiver em execução: aborta com mensagem clara
- Se o lock for stale: avisa, remove o lock e continua

## Validação

- `bash -n` passa
- QA manual em container `archlinux:latest`:
  - A) sem lock -> no-op
  - B) lock stale -> aviso + remoção do lock
  - C) pacman rodando -> aborta com mensagem clara

## Arquivos alterados

- `p3/libs/linuxtoys.lib`